### PR TITLE
Fix identical() function call in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
   out.width = "100%"
 )
 
-on_ci <- identical(Sys.getenv("GITHUB_ACTIONS") == "true")
+on_ci <- identical(Sys.getenv("GITHUB_ACTIONS"), "true")
 ```
 
 # dverse


### PR DESCRIPTION
## Summary
- Fixed missing second argument in `identical()` function call on line 15 of README.Rmd
- The function was calling `identical(Sys.getenv("GITHUB_ACTIONS") == "true")` which was missing the comparison value
- Changed to `identical(Sys.getenv("GITHUB_ACTIONS"), "true")` to properly compare the environment variable

## Test plan
- [x] README.Rmd now renders without errors
- [x] Generated README.md is properly updated
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)